### PR TITLE
Add a v to github-pages-deploy-action version number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
           pip install codespell
           codespell --ignore-words-list=possibile --skip="*.css,*.svg"
 
-      
       - name: Install requirements to generate Psycopg 3 docs
         run: sudo apt-get install -y libgeos-dev
 
@@ -36,7 +35,7 @@ jobs:
         run: make
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.3.4
+        uses: JamesIves/github-pages-deploy-action@v4.3.4
         with:
           branch: master
           folder: build


### PR DESCRIPTION
The `v` was added in v4.2.2.  https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.2.2