### PR TITLE
swap links to psycopg2 and psycopg3 docs on the features page

### DIFF
--- a/content/features/contents.lr
+++ b/content/features/contents.lr
@@ -14,8 +14,8 @@ client library. This makes it complete, performing, reliable, secure.
   pipeline mode) compared to Psycopg 2. Use it if you are developing something
   new!
 
-.. __: /psycopg3/docs/
 .. __: /docs/
+.. __: /psycopg3/docs/
 
 ..
   Please keep consistent with install.rst and setup.py


### PR DESCRIPTION
Links to psycopg2 and psycopg3 docs are currently swapped on the features page https://www.psycopg.org/features/, this change fixes the issue.