### PR TITLE
contents.lr: Psycopg 3 is currently in version 3.2

### DIFF
--- a/content/psycopg3/contents.lr
+++ b/content/psycopg3/contents.lr
@@ -56,7 +56,7 @@ the current patterns in software development and deployment.
 Project funding :raw-html:`<i class="fa fa-heart"></i>`
 -------------------------------------------------------
 
-Psycopg 3 is currently `in version 3.1`__. If you are interested, the
+Psycopg 3 is currently `in version 3.2`__. If you are interested, the
 development has been documented in a series of `blog articles`__.
 
 .. __: https://www.psycopg.org/psycopg3/docs/


### PR DESCRIPTION
```diff
- Psycopg 3 is currently `in version 3.1`__.
+ Psycopg 3 is currently `in version 3.2`__.
```
Updates the https://www.psycopg.org/psycopg3 page to match the version in
* https://pypi.org/project/psycopg and
* https://www.psycopg.org/psycopg3/docs